### PR TITLE
Fix Firefox tooltip transparency

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -91,10 +91,6 @@ GtkGrid:insensitive {
 	color: @theme_tooltip_fg_color;
 }
 
-.tooltip * {
-	background-color: transparent;
-}
-
 /*****************
  * Miscellaneous *
  *****************/


### PR DESCRIPTION
Tooltips are barely readable on gtk3-3.16 and FF 40.

This patch makes them readable again, rendered on yellow backround.

Related to
https://bugzilla.redhat.com/show_bug.cgi?id=1241681