### PR TITLE
Removed errors for GTK+ 3.20+

### DIFF
--- a/gtk-3.0/applications.css
+++ b/gtk-3.0/applications.css
@@ -18,8 +18,6 @@
 	border-image: none;
 }
 
-}
-
 /*******************
  * gnome-documents *
  *******************/

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -150,8 +150,6 @@ spinner:active:disabled {
 	background-image: none;
 	border-style: none;
 	border-image: none;
-	-GtkButton-image-spacing: 0;
-	-GtkButton-inner-border: 0;
 }
 
 .rubberband,
@@ -396,12 +394,6 @@ scale.horizontal {
     padding: 5px 2px;
 }
 
-/*scale {
-	-GtkScale-slider-length: 21;
-	-GtkRange-slider-width: 13;
-	-GtkRange-trough-border: 4;
-}*/
-
 scale.horizontal slider,
 scale.horizontal slider:hover,
 scale.horizontal slider:disabled {
@@ -575,10 +567,6 @@ toolbar.horizontal button:active {
 }
 
 button {
-	-GtkButton-image-spacing: 4px;
-	-GtkButton-interior-focus: true;
-	-GtkButton-default-border: 0;
-	-GtkButton-inner-border: 3px;
 	color: @theme_text_color;
 	border-style: solid;
 	border-color: transparent;
@@ -1325,16 +1313,9 @@ toolbar.primary-toolbar combobox > .linked > button.combo:last-child {
 scrollbar {
 	background-image: none;
 	border-style: solid;
-	/*-GtkRange-trough-border: 0;*/
 	border-color: @scrollbar_trough_border_color;
 	-GtkScrollbar-has-backward-stepper: true;
 	-GtkScrollbar-has-forward-stepper: true;
-	/*-GtkRange-arrow-scaling: 0.4;*/
-	-GtkRange-slider-width: 15;
-	-GtkRange-stepper-size: 15px;
-	-GtkScrollbar-min-slider-length: 30;
-	-GtkRange-stepper-spacing: 0;
-	-GtkRange-trough-under-steppers: 0;
 	box-shadow: none;
 	border-image: none;
 }
@@ -1591,7 +1572,7 @@ treemenu menuitem {
 
 menu,
 .menu {
-	font: normal;
+	font-weight: normal;
 	background-color: @menu_bg_color;
 	color: @menu_fg_color;
 	padding: 1px;
@@ -1973,7 +1954,7 @@ placessidebar .view {
 
 assistant .sidebar highlight {
 	color: @theme_fg_color;
-	font: bold;
+	font-weight: bold;
 }
 
 assistant .sidebar {
@@ -2523,7 +2504,7 @@ infobar:last-child,
 }
 
 .titlebar .title {
-	font: Bold;
+	font-weight: bold;
 }
 
 /*.titlebar :first-child {*/


### PR DESCRIPTION
This mostly removes deprecated CSS properties, but it also fixes a syntax error.  Resolves #39.