### PR TITLE
Add menuitem classes

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -830,6 +830,8 @@ button:active,
 button:hover,
 spinbutton button:hover,
 combobox button.combo:hover,
+menu > menuitem:hover,
+.menu > menuitem:hover
 toolbar button:hover,
 toolbar button.raised:hover,
 toolbar .raised button:hover,


### PR DESCRIPTION
This commit fixes a small issue on on Thunderbird
## Steps to reproduce
On Thunderbird:
* Click on menu
* Move cursor on item

Current behaviour: Letters and background in menuitem is white
Expected behavior: Menu Item should have background like in other menus
